### PR TITLE
[SystemCharacterFeature] -> [develop] Ammo 재장전 구현, 플레이어 초기화 수정 (InGameScene 수정  있음)

### DIFF
--- a/Assets/Scripts/04.IngameScene/Player/Combat/CombatManager.cs
+++ b/Assets/Scripts/04.IngameScene/Player/Combat/CombatManager.cs
@@ -8,6 +8,7 @@ public class CombatManager : MonoBehaviour
     [SerializeField] private PlayerController playerController;
     private Dictionary<WeaponType, IAttackStrategy> _attackStrategies = new Dictionary<WeaponType, IAttackStrategy>();
     private IAttackStrategy _currentStrategy;
+    public IAttackStrategy CurrentStrategy { get => _currentStrategy; set => _currentStrategy = value; }
     private WeaponType _currentWeaponType;
     public GameObject CurrentWeapon { get; set; }
 

--- a/Assets/Scripts/04.IngameScene/Player/Combat/GunAttackStrategy.cs
+++ b/Assets/Scripts/04.IngameScene/Player/Combat/GunAttackStrategy.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public class GunAttackStrategy : IAttackStrategy
+public class GunAttackStrategy : IAttackStrategy ,  IStatObserver
     {
         private static readonly int IsFiring = Animator.StringToHash("IsFiring");
         private PlayerController _playerController;
@@ -9,13 +9,25 @@ public class GunAttackStrategy : IAttackStrategy
         private float _lastFireTime;
         private float _fireRate = 0.2f; // 발사 간격 (초)
         private GunController _gunController;
+        private bool _CanAttack = true;    
+        public bool CanAttack { get => _CanAttack; set => _CanAttack = value; }
+
         
         public void Enter(PlayerController playerController, GameObject weaponObject)
         {
            _playerController = playerController;
-           _gunController = weaponObject.GetComponent<GunController>();
-           
-           _isAttacking = true;
+
+            if (_gunController == null) {     
+               _gunController = weaponObject.GetComponent<GunController>();
+                ReloadAmmo();
+        }
+            _CanAttack = true;
+        
+            _gunController.CurrentAmmo.AddObserver(this); // Observer 등록 ,Observer 당하는 곳에서 중복 처리
+
+            //currentAmmo에 전략 등록
+
+            _isAttacking = true;
            
            _playerController.Animator.SetBool(IsFiring, true);
         }
@@ -54,10 +66,23 @@ public class GunAttackStrategy : IAttackStrategy
         
         private void FireBullet()
         {
+            if (!_CanAttack) return;
             // 탄환 생성 로직 (필요시 구현)
             _gunController.Fire();
-        
+             Debug.Log(_gunController.CurrentAmmo.Value  + " / " + _gunController.MaxAmmo.Value);
             // 발사 시간 기록
             _lastFireTime = Time.time;
         }
-    }
+
+        public void ReloadAmmo() {
+            _gunController.CurrentAmmo.Value = _gunController.MaxAmmo.Value; 
+        }
+        public void WhenStatChanged((float, string) data)
+        {
+            //총알이 0이 되면 
+            if (data.Item1 <= 0) {
+                _CanAttack = false;
+                _playerController.SetActionState("Reload");
+            }
+        }
+}

--- a/Assets/Scripts/04.IngameScene/Player/FSM/PlayerFSM.cs
+++ b/Assets/Scripts/04.IngameScene/Player/FSM/PlayerFSM.cs
@@ -39,6 +39,7 @@ public static class StateFactory
         (ActionState.Attack, new AttackState(/*_aniStrategy*/)),
         (ActionState.Hit, new HitState(/*_aniStrategy*/)),
         (ActionState.Dead, new DeadState(/*_aniStrategy*/)),
+        (ActionState.Reload, new ReloadState(/*_aniStrategy*/)),
         //(ActionState.MovementSkills, new MovementSkillsState(/*_aniStrategy*/)),
         //(ActionState.WeaponSkills, new WeaponSkillsState(/*_aniStrategy*/))
     };

--- a/Assets/Scripts/04.IngameScene/Player/PlayerController.cs
+++ b/Assets/Scripts/04.IngameScene/Player/PlayerController.cs
@@ -12,6 +12,7 @@ public enum ActionState
     Idle,
     Attack,
     Hit,
+    Reload,
     Dead,
     MovementSkills,
     WeaponSkills,
@@ -158,6 +159,8 @@ public class PlayerController : MonoBehaviour, IInputEvents, IDamageable, IStatO
     private PlayerFSM<MovementState> _movementFsm;
     private PlayerFSM<PostureState> _postureFsm;
     private PlayerFSM<ActionState> _actionFsm;
+    private bool _CanChangeState = true;
+    public bool CanChangeState { get => _CanChangeState; set => _CanChangeState =  value; }
     [SerializeField] private string defaultState;
 
     public PlayerFSM<MovementState> MovementFsm { get => _movementFsm; }
@@ -258,6 +261,12 @@ public class PlayerController : MonoBehaviour, IInputEvents, IDamageable, IStatO
 
     public void SetActionState(string stateName)
     {
+        if (stateName == "Reload") {
+            _CanChangeState = false;
+            _actionFsm.ChangeState(stateName, this);
+            return;
+        }
+        if (!_CanChangeState) return;
         _actionFsm.ChangeState(stateName, this);
     }
 
@@ -271,6 +280,8 @@ public class PlayerController : MonoBehaviour, IInputEvents, IDamageable, IStatO
         _combatManager.SetWeaponType(weapon.WeaponType);
 
         _combatManager.CurrentWeapon = _playerWeapon.CurrentWeapon;
+
+        _CanChangeState = true;
     }
 
     // 데이지 계산
@@ -422,6 +433,14 @@ public class PlayerController : MonoBehaviour, IInputEvents, IDamageable, IStatO
             _combatManager.ProcessInput(false, false);
         }
     }
+
+    public void OnReloadPressed() {
+        if (_playerWeapon.WeaponType == WeaponType.Gun) { 
+            SetActionState("Reload");
+        }
+    }
+
+
 
     public void OnCrouchPressed()
     {
@@ -922,8 +941,6 @@ public class PlayerController : MonoBehaviour, IInputEvents, IDamageable, IStatO
         _secondMovementSkillCoolTimeCoroutine = null;
         _firstWeaponSkillCoolTimeCoroutine = null;
         _secondWeaponSkillCoolTimeCoroutine = null;
-
-        _purchaseManager = null;
     }
 
 

--- a/Assets/Scripts/04.IngameScene/Player/PlayerInput/IInputEvents.cs
+++ b/Assets/Scripts/04.IngameScene/Player/PlayerInput/IInputEvents.cs
@@ -22,4 +22,6 @@ public interface IInputEvents
 
     void OnSecondMoveSkillPressed();
     void OnSecondMoveSkillReleased();
+
+    void OnReloadPressed();
 }

--- a/Assets/Scripts/04.IngameScene/Player/PlayerInput/InputManager.cs
+++ b/Assets/Scripts/04.IngameScene/Player/PlayerInput/InputManager.cs
@@ -42,5 +42,6 @@ public class InputManager : MonoBehaviour
         if (Input.GetButtonUp("FirstMoveSkill")) _listener?.OnFirstMoveSkillReleased();
         if (Input.GetButtonDown("SecondMoveSkill")) _listener?.OnSecondMoveSkillPressed();
         if (Input.GetButtonUp("SecondMoveSkill")) _listener?.OnSecondMoveSkillReleased();
+        if (Input.GetButtonUp("Reload")) _listener?.OnReloadPressed();
     }
 }

--- a/Assets/Scripts/04.IngameScene/Player/PlayerStates/Actions/ReloadState.cs
+++ b/Assets/Scripts/04.IngameScene/Player/PlayerStates/Actions/ReloadState.cs
@@ -6,21 +6,30 @@ public class ReloadState : PlayerActionState
 {
     private static int aniName;
     public ReloadState() : base() { }
-    //public ReloadState(IWeaponAnimationStrategy iWeaponAnimationStrategy) : base(iWeaponAnimationStrategy)
-    //{
-    //    aniName = Animator.StringToHash(_aniStrategy.GetAnimationName("Reload"));
-    //}
+  
     public override void Enter(PlayerController playerController)
     {
-        //playerController.Animator.Play(aniName);
         base.Enter(playerController);
+        _playerController.StartCoroutine(Reloading());
     }
     public override void Exit()
     {
         base.Exit();
+        var gun = ((GunAttackStrategy)_playerController.CombatManager.CurrentStrategy);
+        gun.ReloadAmmo();
+        gun.CanAttack = true;
     }
     public override void StateUpdate()
     {
-        base.StateUpdate();
+    }
+    IEnumerator Reloading() {
+        float f= 0;
+        while (f < 5) {
+            f += Time.deltaTime;
+            Debug.Log($"{f}초 재장전 중");
+            yield return  null;
+        }
+        _playerController.CanChangeState = true;
+        _playerController.SetActionState("Idle");
     }
 }

--- a/Assets/Scripts/04.IngameScene/Player/PlayerWeapon/GunController.cs
+++ b/Assets/Scripts/04.IngameScene/Player/PlayerWeapon/GunController.cs
@@ -230,6 +230,8 @@ public class GunController : MonoBehaviour, IWeapon
             ApplyDamage(_hitInfo.collider.gameObject, _hitInfo.point, firePoint.forward);
         }
         
+        _currentAmmo.Value -= 1;
+
         // 총알 시뮬레이션
         EffectPrefab? bulletPrefab = GetEffectPrefab(EffectType.Bullet);
         if (bulletPrefab.HasValue && bulletPrefab.Value.prefab != null)

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -246,11 +246,11 @@ InputManager:
     axis: 0
     joyNum: 0
   - serializedVersion: 3
-    m_Name: Enable Debug Button 1
+    m_Name: Reload
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: left ctrl
+    positiveButton: r
     altNegativeButton: 
     altPositiveButton: joystick button 8
     gravity: 0
@@ -436,5 +436,21 @@ InputManager:
     invert: 0
     type: 2
     axis: 5
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: Enable Debug Button 1
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: left ctrl
+    altNegativeButton: 
+    altPositiveButton: joystick button 8
+    gravity: 0
+    dead: 0
+    sensitivity: 0
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
     joyNum: 0
   m_UsePhysicalKeys: 1


### PR DESCRIPTION
Ammo 재장전 구현, 플레이어 초기화 수정
- 플레이어 초기화 시 무기 초기화 부분 null로 날려버려  다음 무기 구매  시  null 참조가 뜨던 오류 수정
- Gun의 Ammo와 재장전 구현
- InGameScene의 Audio Listener가 2개인 문제가 있어 Main Camera의 Listener를 비활성화 해둠 or 비활성화 필요